### PR TITLE
Add ability to force a hub to send the payload

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
 
      <dt>payload.ct <span class="property-type">string</span></dt>
      <dd>The mired color temperature of the light (min 153, max 500)</dd>
+
+     <dt>payload.forceSend <span class="property-type">boolean</span></dt>
+     <dd>Force the hub to send the payload, even when state is unchanged</dd>
   </dl>
 
   <h3>Outputs</h3>

--- a/index.js
+++ b/index.js
@@ -98,13 +98,15 @@ module.exports = function(RED) {
 
         msg.payload.deviceid = formatUUID(nodeDeviceId);
 
-        // Send payload if state is changed
-        var stateChanged = false;
-        var deviceAttributes = getDeviceAttributes(msg.payload.deviceid, hubNode.context());
+        // Send payload if state is changed or force send is set
+        var stateChanged = msg.payload.forceSend ? true : false;
+        if (!stateChanged) {
+          var deviceAttributes = getDeviceAttributes(msg.payload.deviceid, hubNode.context());
 
-        for (var key in msg.payload) {
-          if (key in deviceAttributes && msg.payload[key] !== deviceAttributes[key]) {
-            stateChanged = true;
+          for (var key in msg.payload) {
+            if (key in deviceAttributes && msg.payload[key] !== deviceAttributes[key]) {
+              stateChanged = true;
+            }
           }
         }
 


### PR DESCRIPTION
When `msg.payload.forceSend` is set the hub will not determine if the state of the node changed, forcing a send regardless of it.

This is useful when the actual state of the device changes without knowledge of the hub.